### PR TITLE
Fix page breaks by using QT 4.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Usage: PrintHtml [-test] [-p printer] [-l left] [-t top] [-r right] [-b bottom] 
 
 -test         - Don't print, just show what would have printed.
 -p printer    - Printer to print to. Use 'Default' for default printer.
+-a page       - Paper type [A4|A3|US letter]
 -l left       - Optional left margin for page.
 -t top        - Optional top margin for page.
 -r right      - Optional right margin for page.

--- a/main.cpp
+++ b/main.cpp
@@ -57,7 +57,7 @@ int main(
         usage += "-t top         - Optional top margin for page.\n";
         usage += "-r right       - Optional right margin for page.\n";
         usage += "-b bottom      - Optional bottom margin for page.\n";
-        usage += "-a [A4|Letter] - Optional paper type.\n";
+        usage += "-a [A4|A5|Letter] - Optional paper type.\n";
         usage += "url            - Defines the list of URLs to print, one after the other.\n";
         QMessageBox msgBox;
         msgBox.setWindowTitle("PrintHtml Usage");

--- a/printhtml.cpp
+++ b/printhtml.cpp
@@ -42,6 +42,8 @@ PrintHtml::PrintHtml(bool testMode, QStringList urls, QString selectedPrinter, d
     printer->setOrientation(QPrinter::Portrait);
     if (paper == "A4") {
         printer->setPaperSize(QPrinter::A4);
+    } else if(paper == "A5") {
+        printer->setPaperSize(QPrinter::A5);
     } else {
         printer->setPaperSize(QPrinter::Letter);
     }


### PR DESCRIPTION
QT 4.8 has an issue where page breaks are not honored as noted [here](https://forum.qt.io/topic/16692/printing-a-qwebview-doesn-t-seem-to-honour-page-breaks/2).
This pull request also adds A5 paper.